### PR TITLE
Preserve Vitest run failures in results.json

### DIFF
--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -1177,6 +1177,26 @@ The pathgrade reporter prints an aggregate summary after vitest completes:
 
 Every run writes a consolidated `.pathgrade/results.json` (plus per-group trace files under `.pathgrade/traces/`) in the project directory. The directory is auto-gitignored on first write. Use `reporter: 'browser'` to open an interactive viewer after each run, or invoke `npx pathgrade preview` / `npx pathgrade preview browser` later. By default, successful evals print a one-line diagnostics summary, while failures and timeouts print the full diagnostics breakdown automatically. Set `diagnostics: true` in the plugin or pass `pathgrade run --diagnostics` to force full diagnostics on successful runs too.
 
+New reports include a `run` object with Vitest's final reason and normalized module, suite, or unhandled failures. This is written even when a setup hook fails before any eval completes, so CI artifact collectors can preserve the failure instead of finding no `results.json`:
+
+```json
+{
+  "status": "fail",
+  "groups": [],
+  "run": {
+    "reason": "failed",
+    "failures": [
+      {
+        "scope": "suite",
+        "file": "agent.eval.ts",
+        "suite": "agent setup",
+        "message": "Hook timed out in 900000ms."
+      }
+    ]
+  }
+}
+```
+
 ## CI Integration
 
 ```yaml

--- a/src/plugin/reporter.ts
+++ b/src/plugin/reporter.ts
@@ -1,11 +1,11 @@
 import * as path from 'path';
 import { execSync } from 'child_process';
-import type { Reporter, TestModule } from 'vitest/node';
+import type { Reporter, TestModule, TestRunEndReason } from 'vitest/node';
 import type { PathgradePluginOptions } from '../sdk/types.js';
 import { fmt } from '../utils/cli.js';
 import { getPathgradeDir } from '../reporters/results-path.js';
 import { readSidecar } from '../affected/sidecar.js';
-import { collectVitestReportGroups } from '../reporting/vitest-edge.js';
+import { collectVitestReportGroups, collectVitestRunResult } from '../reporting/vitest-edge.js';
 import { buildPathgradeReport } from '../reporting/core.js';
 import { writePathgradeArtifacts } from '../reporting/artifacts.js';
 import { printReportSummary } from '../reporters/report-summary.js';
@@ -21,18 +21,21 @@ export class PathgradeReporter implements Reporter {
         this.opts = opts ?? {};
     }
 
-    async onTestRunEnd(testModules: ReadonlyArray<TestModule>): Promise<void> {
+    async onTestRunEnd(
+        testModules: ReadonlyArray<TestModule>,
+        unhandledErrors: Parameters<NonNullable<Reporter['onTestRunEnd']>>[1] = [],
+        reason: TestRunEndReason = 'passed',
+    ): Promise<void> {
         const groups = collectVitestReportGroups(testModules);
         const built = buildPathgradeReport({
             threshold: this.opts.ci?.threshold,
+            run: collectVitestRunResult(testModules, unhandledErrors, reason),
             groups,
         });
 
         for (const warning of built.warnings) {
             console.warn(`  [pathgrade] warning: ${warning}`);
         }
-
-        if (built.report.groups.length === 0) return;
 
         const selection = await readSidecar(process.cwd(), msg => {
             console.warn(`[pathgrade] ${msg}`);
@@ -43,7 +46,7 @@ export class PathgradeReporter implements Reporter {
 
         const mode = this.opts.reporter ?? 'cli';
 
-        if (mode === 'cli' || mode === 'browser') {
+        if ((mode === 'cli' || mode === 'browser') && built.summaries.length > 0) {
             printReportSummary(built.summaries, {
                 forceVerbose: this.opts.diagnostics === true || process.env.PATHGRADE_DIAGNOSTICS === '1',
                 currentTimeoutMs: this.opts.timeout != null ? this.opts.timeout * 1000 : undefined,
@@ -60,7 +63,7 @@ export class PathgradeReporter implements Reporter {
 
         if (this.opts.ci?.threshold != null) {
             const avg = built.report.overall_pass_rate;
-            if (built.report.status === 'fail') {
+            if (avg < this.opts.ci.threshold) {
                 console.log(
                     `\n  ${fmt.fail('CI THRESHOLD FAILED')}  avg score ${fmt.bold(avg.toFixed(3))} < threshold ${fmt.bold(String(this.opts.ci.threshold))}\n`,
                 );

--- a/src/reporters/github-comment.ts
+++ b/src/reporters/github-comment.ts
@@ -12,6 +12,7 @@ import * as fs from 'fs';
 import type {
     PathgradeGroupReport,
     PathgradeReport,
+    PathgradeRunResult,
     PathgradeSelectionReport,
     StrippedTrialResult,
 } from '../types.js';
@@ -61,6 +62,22 @@ function escapeTableCell(value: string): string {
     return value.replace(/\|/g, '\\|').replace(/\n/g, ' ');
 }
 
+function formatRunSection(run: PathgradeRunResult): string {
+    const lines = [
+        '### Vitest run',
+        `Run ended as **${run.reason.toUpperCase()}**.`,
+    ];
+
+    for (const failure of run.failures) {
+        const location = [failure.file, failure.suite].filter(Boolean).join(' > ');
+        const locationLabel = location ? ` \`${location.replace(/`/g, '\\`')}\`` : '';
+        const message = failure.message.replace(/\r?\n/g, ' ');
+        lines.push(`- \`${failure.scope}\`${locationLabel}: ${message}`);
+    }
+
+    return lines.join('\n');
+}
+
 /**
  * Format a pathgrade PR comment as markdown.
  *
@@ -89,8 +106,14 @@ export function formatReportMarkdown(
     );
 
     if (report.threshold != null) {
+        const thresholdStatus = p >= report.threshold ? 'PASS' : 'FAIL';
         lines.push('');
-        lines.push(`Threshold: ${pct(report.threshold)} — ${report.status.toUpperCase()}`);
+        lines.push(`Threshold: ${pct(report.threshold)} — ${thresholdStatus}`);
+    }
+
+    if (report.run && (report.run.reason !== 'passed' || report.run.failures.length > 0)) {
+        lines.push('');
+        lines.push(formatRunSection(report.run));
     }
 
     lines.push('');

--- a/src/reporting/core.ts
+++ b/src/reporting/core.ts
@@ -56,9 +56,12 @@ export function buildPathgradeReport(input: ReportRunInput): PathgradeReportBuil
 
     const scores = reportableGroups.flatMap(group => group.cases.map(testCase => testCase.score));
     const overallPassRate = average(scores);
-    const status = input.threshold != null
+    const scoreStatus = input.threshold != null
         ? (overallPassRate >= input.threshold ? 'pass' : 'fail')
         : (reportableGroups.every(group => group.cases.every(testCase => testCase.state === 'passed')) ? 'pass' : 'fail');
+    const runPassed = input.run == null
+        || (input.run.reason === 'passed' && input.run.failures.length === 0);
+    const status = scoreStatus === 'pass' && runPassed ? 'pass' : 'fail';
 
     return {
         report: {
@@ -68,6 +71,7 @@ export function buildPathgradeReport(input: ReportRunInput): PathgradeReportBuil
             overall_pass_rate: overallPassRate,
             status,
             groups: consolidatedGroups,
+            ...(input.run ? { run: input.run } : {}),
             ...(input.selection ? { selection: input.selection } : {}),
         },
         traces,

--- a/src/reporting/types.ts
+++ b/src/reporting/types.ts
@@ -1,11 +1,12 @@
 import type { DiagnosticsReport } from '../sdk/diagnostics.js';
-import type { PathgradeReport, PathgradeSelectionReport, TrialResult } from '../types.js';
+import type { PathgradeReport, PathgradeRunResult, PathgradeSelectionReport, TrialResult } from '../types.js';
 
 export type ReportCaseState = 'passed' | 'failed' | 'skipped' | 'pending';
 
 export interface ReportRunInput {
     threshold?: number;
     selection?: PathgradeSelectionReport;
+    run?: PathgradeRunResult;
     groups: ReportGroupInput[];
 }
 

--- a/src/reporting/vitest-edge.ts
+++ b/src/reporting/vitest-edge.ts
@@ -1,6 +1,9 @@
-import type { TestCase, TestModule, TestSuite } from 'vitest/node';
+import type { Reporter, TestCase, TestModule, TestRunEndReason, TestSuite } from 'vitest/node';
 import type { PathgradeTestMeta } from '../sdk/types.js';
+import type { PathgradeRunFailure, PathgradeRunResult } from '../types.js';
 import type { ReportCaseInput, ReportCaseState, ReportGroupInput } from './types.js';
+
+type VitestRunError = Parameters<NonNullable<Reporter['onTestRunEnd']>>[1][number];
 
 export function collectVitestReportGroups(testModules: ReadonlyArray<TestModule>): ReportGroupInput[] {
     const groupMap = new Map<string, ReportCaseInput[]>();
@@ -20,6 +23,52 @@ export function collectVitestReportGroups(testModules: ReadonlyArray<TestModule>
         groupName,
         cases,
     }));
+}
+
+export function collectVitestRunResult(
+    testModules: ReadonlyArray<TestModule>,
+    unhandledErrors: ReadonlyArray<VitestRunError>,
+    reason: TestRunEndReason,
+): PathgradeRunResult {
+    const failures: PathgradeRunFailure[] = [];
+
+    for (const mod of testModules) {
+        const file = mod.relativeModuleId || undefined;
+        appendFailures(failures, getErrors(mod), { scope: 'module', file });
+
+        const suites = mod.children.allSuites?.();
+        if (suites) {
+            for (const suite of suites) {
+                appendFailures(failures, getErrors(suite), {
+                    scope: 'suite',
+                    file,
+                    suite: suite.fullName,
+                });
+            }
+        }
+    }
+
+    appendFailures(failures, unhandledErrors, { scope: 'unhandled' });
+    return { reason, failures };
+}
+
+function getErrors(owner: { errors?: () => ReadonlyArray<VitestRunError> }): ReadonlyArray<VitestRunError> {
+    return owner.errors?.() ?? [];
+}
+
+function appendFailures(
+    target: PathgradeRunFailure[],
+    errors: ReadonlyArray<VitestRunError>,
+    location: Pick<PathgradeRunFailure, 'scope' | 'file' | 'suite'>,
+): void {
+    for (const error of errors) {
+        target.push({
+            ...location,
+            message: error.message,
+            ...(error.name ? { name: error.name } : {}),
+            ...(error.stack ? { stack: error.stack } : {}),
+        });
+    }
 }
 
 function getGroupName(testCase: TestCase): string {

--- a/src/types.ts
+++ b/src/types.ts
@@ -234,6 +234,22 @@ export interface PathgradeSelectionReport {
     }>;
 }
 
+export type PathgradeRunEndReason = 'passed' | 'failed' | 'interrupted';
+
+export interface PathgradeRunFailure {
+    scope: 'module' | 'suite' | 'unhandled';
+    message: string;
+    name?: string;
+    stack?: string;
+    file?: string;
+    suite?: string;
+}
+
+export interface PathgradeRunResult {
+    reason: PathgradeRunEndReason;
+    failures: PathgradeRunFailure[];
+}
+
 /**
  * Shape of `.pathgrade/results.json` — the consolidated consolidated pathgrade
  * run report. `version` is pinned to 1 so the `pathgrade report` command and
@@ -247,12 +263,17 @@ export interface PathgradeReport {
     /** Weighted average of every individual trial score across all groups. */
     overall_pass_rate: number;
     /**
-     * Threshold check result. When `threshold` is set: `'pass'` iff
-     * `overall_pass_rate >= threshold`. Otherwise: `'pass'` iff every trial
-     * in every group passed its vitest test.
+     * Overall result. A failed or interrupted runner forces `'fail'`. Otherwise,
+     * when `threshold` is set: `'pass'` iff `overall_pass_rate >= threshold`.
+     * Without a threshold: `'pass'` iff every trial passed its vitest test.
      */
     status: 'pass' | 'fail';
     groups: PathgradeGroupReport[];
+    /**
+     * Vitest's run-level outcome, including failures that happened before an
+     * individual eval completed. Optional for compatibility with older reports.
+     */
+    run?: PathgradeRunResult;
     /**
      * Present when `pathgrade run --changed` produced the run. Absent on
      * plain `pathgrade run`. Backward compatible — older consumers ignore

--- a/tests/plugin.reporter-modes.test.ts
+++ b/tests/plugin.reporter-modes.test.ts
@@ -108,4 +108,31 @@ describe('PathgradeReporter modes and threshold behavior', () => {
         expect(output).toContain('avg score 0.250 < threshold 0.8');
         expect(process.exitCode).toBe(1);
     });
+
+    it('does not misreport a runner failure as a threshold failure', async () => {
+        const fs = (await import('fs-extra')).default;
+        const { PathgradeReporter } = await import('../src/plugin/reporter.js');
+
+        const reporter = new PathgradeReporter({ reporter: 'json', ci: { threshold: 0.8 } });
+        await reporter.onTestRunEnd(
+            [{ children: { allTests: () => [makeTestCase(1)] } }] as any,
+            [{ message: 'worker exited unexpectedly' }],
+            'failed',
+        );
+
+        const output = logSpy.mock.calls.map(call => String(call[0])).join('\n');
+        expect(output).not.toContain('CI THRESHOLD FAILED');
+        expect(process.exitCode).toBeUndefined();
+        const resultsCall = vi.mocked(fs.writeJson).mock.calls.find(
+            ([p]) => typeof p === 'string' && p.endsWith('results.json'),
+        );
+        expect(resultsCall![1]).toMatchObject({
+            overall_pass_rate: 1,
+            status: 'fail',
+            run: {
+                reason: 'failed',
+                failures: [{ scope: 'unhandled', message: 'worker exited unexpectedly' }],
+            },
+        });
+    });
 });

--- a/tests/plugin.reporter-preview.test.ts
+++ b/tests/plugin.reporter-preview.test.ts
@@ -134,6 +134,61 @@ describe('PathgradeReporter consolidated output', () => {
         cwdSpy.mockRestore();
     });
 
+    it('writes run failures when a beforeAll hook prevents evals from completing', async () => {
+        const cwdSpy = vi.spyOn(process, 'cwd').mockReturnValue('/tmp/my-project');
+        const { PathgradeReporter } = await import('../src/plugin/reporter.js');
+        const fs = (await import('fs-extra')).default;
+        vi.mocked(fs.ensureDir).mockResolvedValue(undefined);
+        vi.mocked(fs.writeFile).mockResolvedValue(undefined);
+        const writeJsonSpy = vi.mocked(fs.writeJson).mockResolvedValue(undefined);
+        writeJsonSpy.mockClear();
+
+        const pendingCase = {
+            ...makeTestCase(),
+            meta: () => ({}),
+            result: () => ({ state: 'pending' }),
+        };
+        const hookError = {
+            name: 'Error',
+            message: 'Hook timed out in 900000ms.',
+            stack: 'Error: Hook timed out in 900000ms.\n    at setup.eval.ts:10:1',
+        };
+        const testModules = [{
+            relativeModuleId: 'setup.eval.ts',
+            errors: () => [],
+            children: {
+                allTests: () => [pendingCase],
+                allSuites: () => [{
+                    fullName: 'agent setup',
+                    errors: () => [hookError],
+                }],
+            },
+        }] as any;
+
+        const reporter = new PathgradeReporter({ reporter: 'json' });
+        await reporter.onTestRunEnd(testModules, [], 'failed');
+
+        const resultsCall = writeJsonSpy.mock.calls.find(
+            ([p]) => typeof p === 'string' && p.endsWith('results.json'),
+        );
+        expect(resultsCall).toBeDefined();
+        expect(resultsCall![1]).toMatchObject({
+            status: 'fail',
+            groups: [],
+            run: {
+                reason: 'failed',
+                failures: [{
+                    scope: 'suite',
+                    file: 'setup.eval.ts',
+                    suite: 'agent setup',
+                    message: 'Hook timed out in 900000ms.',
+                }],
+            },
+        });
+
+        cwdSpy.mockRestore();
+    });
+
     it('writes trace files with full trial data including session_log', async () => {
         const cwdSpy = vi.spyOn(process, 'cwd').mockReturnValue('/tmp/my-project');
         const { PathgradeReporter } = await import('../src/plugin/reporter.js');

--- a/tests/plugin.reporter-selection.test.ts
+++ b/tests/plugin.reporter-selection.test.ts
@@ -133,12 +133,21 @@ describe('PathgradeReporter — selection sidecar merge (Issue 11)', () => {
         cwdSpy.mockRestore();
     });
 
-    it('does not read selection sidecars when there are no reportable cases', async () => {
+    it('preserves selection metadata when there are no reportable cases', async () => {
         const cwdSpy = vi.spyOn(process, 'cwd').mockReturnValue('/tmp/p4');
         const { PathgradeReporter } = await import('../src/plugin/reporter.js');
         const fs = (await import('fs-extra')).default;
+        vi.mocked(fs.ensureDir).mockResolvedValue(undefined);
+        vi.mocked(fs.writeFile).mockResolvedValue(undefined);
+        const writeJsonSpy = vi.mocked(fs.writeJson).mockResolvedValue(undefined);
+        const sidecar = {
+            base_ref: 'origin/main@abc1234',
+            changed_files_count: 1,
+            selected: ['skills/alpha/a.eval.ts'],
+            skipped: [],
+        };
         vi.mocked(fs.pathExists).mockResolvedValue(true as any);
-        vi.mocked(fs.readJSON).mockRejectedValue(new Error('unexpected token'));
+        vi.mocked(fs.readJSON).mockResolvedValue(sidecar);
 
         const reporter = new PathgradeReporter({ reporter: 'cli' });
         await reporter.onTestRunEnd([{
@@ -151,10 +160,18 @@ describe('PathgradeReporter — selection sidecar merge (Issue 11)', () => {
             },
         }] as any);
 
-        expect(fs.readJSON).not.toHaveBeenCalled();
+        expect(fs.readJSON).toHaveBeenCalled();
         expect(warnSpy).toHaveBeenCalledWith(
             '  [pathgrade] warning: empty results for "trial 1" — evaluate() may not have been called',
         );
+        const resultsCall = writeJsonSpy.mock.calls.find(
+            ([p]) => typeof p === 'string' && p.endsWith('results.json'),
+        );
+        expect(resultsCall![1]).toMatchObject({
+            status: 'pass',
+            groups: [],
+            selection: sidecar,
+        });
         cwdSpy.mockRestore();
     });
 });

--- a/tests/reporters.github-comment.test.ts
+++ b/tests/reporters.github-comment.test.ts
@@ -83,6 +83,37 @@ describe('formatReportMarkdown', () => {
         expect(md).toContain('❌');
     });
 
+    it('renders runner failure separately from a passing score threshold', () => {
+        const md = formatReportMarkdown(makeReport({
+            threshold: 0.7,
+            overall_pass_rate: 0.879,
+            status: 'fail',
+            run: {
+                reason: 'failed',
+                failures: [{
+                    scope: 'suite',
+                    file: 'agent.eval.ts',
+                    suite: 'agent setup',
+                    message: 'Hook timed out in 900000ms.',
+                }],
+            },
+        }), { commentId: 'default' });
+
+        expect(md).toContain('❌');
+        expect(md).toContain('Threshold: 70.0% — PASS');
+        expect(md).toContain('### Vitest run');
+        expect(md).toContain('Run ended as **FAILED**.');
+        expect(md).toContain('`suite` `agent.eval.ts > agent setup`: Hook timed out in 900000ms.');
+    });
+
+    it('omits the Vitest run section for successful runs', () => {
+        const md = formatReportMarkdown(makeReport({
+            run: { reason: 'passed', failures: [] },
+        }), { commentId: 'default' });
+
+        expect(md).not.toContain('### Vitest run');
+    });
+
     it('includes overall pass rate, pass@k, pass^k as percentages', () => {
         const md = formatReportMarkdown(makeReport(), { commentId: 'default' });
         // overall_pass_rate = 0.75 = 75.0%

--- a/tests/reporting-core.contract.test.ts
+++ b/tests/reporting-core.contract.test.ts
@@ -218,4 +218,65 @@ describe('runner-neutral reporting contract', () => {
         expect(built.report.groups).toEqual([]);
         expect(built.traces).toEqual([]);
     });
+
+    it('preserves run failures when no eval case completes', () => {
+        const built = buildPathgradeReport({
+            run: {
+                reason: 'failed',
+                failures: [{
+                    scope: 'suite',
+                    file: 'setup.eval.ts',
+                    suite: 'agent setup',
+                    name: 'Error',
+                    message: 'Hook timed out in 900000ms.',
+                    stack: 'Error: Hook timed out in 900000ms.\n    at setup.eval.ts:10:1',
+                }],
+            },
+            groups: [{
+                groupName: 'setup.eval.ts > agent setup',
+                cases: [{
+                    name: 'runs the eval',
+                    state: 'pending',
+                    runnerDurationMs: 0,
+                }],
+            }],
+        });
+
+        expect(built.report).toMatchObject({
+            status: 'fail',
+            overall_pass_rate: 0,
+            groups: [],
+            run: {
+                reason: 'failed',
+                failures: [{
+                    scope: 'suite',
+                    file: 'setup.eval.ts',
+                    suite: 'agent setup',
+                    message: 'Hook timed out in 900000ms.',
+                }],
+            },
+        });
+    });
+
+    it('lets a run failure override an otherwise passing threshold', () => {
+        const built = buildPathgradeReport({
+            threshold: 0.8,
+            run: {
+                reason: 'failed',
+                failures: [{ scope: 'unhandled', message: 'worker exited unexpectedly' }],
+            },
+            groups: [{
+                groupName: 'passing.eval.ts',
+                cases: [{
+                    name: 'scored well before the worker failed',
+                    state: 'passed',
+                    runnerDurationMs: 10,
+                    evaluations: [{ score: 1 }],
+                }],
+            }],
+        });
+
+        expect(built.report.overall_pass_rate).toBe(1);
+        expect(built.report.status).toBe('fail');
+    });
 });

--- a/tests/reporting-vite-edge.test.ts
+++ b/tests/reporting-vite-edge.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { collectVitestReportGroups } from '../src/reporting/vitest-edge.js';
+import { collectVitestReportGroups, collectVitestRunResult } from '../src/reporting/vitest-edge.js';
 
 function makeCase(overrides: {
     name: string;
@@ -81,5 +81,59 @@ describe('Vitest reporting edge', () => {
                 ],
             },
         ]);
+    });
+
+    it('collects module, suite, and unhandled run failures', () => {
+        const run = collectVitestRunResult([
+            {
+                relativeModuleId: 'setup.eval.ts',
+                errors: () => [{
+                    name: 'SyntaxError',
+                    message: 'Failed to load setup',
+                    stack: 'SyntaxError: Failed to load setup',
+                }],
+                children: {
+                    allSuites: () => [{
+                        fullName: 'agent setup > authenticated session',
+                        errors: () => [{
+                            name: 'Error',
+                            message: 'Hook timed out in 900000ms.',
+                            stack: 'Error: Hook timed out in 900000ms.',
+                        }],
+                    }],
+                },
+            },
+        ] as any, [{
+            name: 'Error',
+            message: 'worker exited unexpectedly',
+            stack: 'Error: worker exited unexpectedly',
+        }], 'failed');
+
+        expect(run).toEqual({
+            reason: 'failed',
+            failures: [
+                {
+                    scope: 'module',
+                    file: 'setup.eval.ts',
+                    name: 'SyntaxError',
+                    message: 'Failed to load setup',
+                    stack: 'SyntaxError: Failed to load setup',
+                },
+                {
+                    scope: 'suite',
+                    file: 'setup.eval.ts',
+                    suite: 'agent setup > authenticated session',
+                    name: 'Error',
+                    message: 'Hook timed out in 900000ms.',
+                    stack: 'Error: Hook timed out in 900000ms.',
+                },
+                {
+                    scope: 'unhandled',
+                    name: 'Error',
+                    message: 'worker exited unexpectedly',
+                    stack: 'Error: worker exited unexpectedly',
+                },
+            ],
+        });
     });
 });


### PR DESCRIPTION
## Summary

- record Vitest run end reason and normalized module, suite, and unhandled failures
- always write `.pathgrade/results.json` when no eval case completes
- make run failures override an otherwise passing score while keeping threshold diagnostics accurate
- document the additive `run` report field

## Motivation

When a setup hook fails or times out, eval cases can remain pending. PathGrade previously filtered those cases and returned before writing artifacts, leaving CI artifact collectors with no structured explanation. This preserves the Vitest failure in the normal PathGrade report contract.

## Testing

- `yarn build`
- focused reporter/reporting suite: 22 tests passed
- `yarn quality:boundaries`
- `yarn quality:max-lines`
- full local suite: 1,252 tests passed; the only failure was the existing macOS Unix-socket fixture hitting `EINVAL` because its socket path exceeds the platform limit (`tests/sandbox.test.ts:874`)
