### PR TITLE
fix: safely clean stale PathGrade trial sandboxes

### DIFF
--- a/src/providers/sandbox-lifecycle.ts
+++ b/src/providers/sandbox-lifecycle.ts
@@ -1,0 +1,164 @@
+import fs from 'fs-extra';
+import * as os from 'os';
+import * as path from 'path';
+
+export const SANDBOX_PREFIX = 'pathgrade-';
+export const SANDBOX_MARKER = '.pathgrade-sandbox.json';
+export const STALE_SANDBOX_AGE_MS = 24 * 60 * 60 * 1_000;
+
+let startupCleanup: Promise<void> | undefined;
+
+const SANDBOX_REMOVE_RETRY_DELAYS_MS = [
+    50,
+    100,
+    250,
+    500,
+    1_000,
+    2_000,
+    3_000,
+    5_000,
+];
+
+interface RemoveSandboxRootOptions {
+    remove?: (target: string) => Promise<void>;
+    sleep?: (ms: number) => Promise<void>;
+    retryDelaysMs?: readonly number[];
+}
+
+function isRetryableRemoveError(error: unknown): boolean {
+    const code = (error as NodeJS.ErrnoException).code;
+    return code === 'ENOTEMPTY' || code === 'EBUSY' || code === 'EPERM';
+}
+
+export async function removeSandboxRoot(
+    rootDir: string,
+    opts: RemoveSandboxRootOptions = {},
+): Promise<void> {
+    const remove = opts.remove ?? ((target) => fs.remove(target));
+    const sleep = opts.sleep ?? ((ms) => new Promise<void>((resolve) => setTimeout(resolve, ms)));
+    const retryDelaysMs = opts.retryDelaysMs ?? SANDBOX_REMOVE_RETRY_DELAYS_MS;
+
+    for (let attempt = 0; ; attempt++) {
+        try {
+            await remove(rootDir);
+            return;
+        } catch (error) {
+            if (!isRetryableRemoveError(error) || attempt >= retryDelaysMs.length) {
+                throw error;
+            }
+            await sleep(retryDelaysMs[attempt]);
+        }
+    }
+}
+
+interface SandboxMarker {
+    version: 1;
+    pid: number;
+}
+
+export interface StaleSandboxCleanupOptions extends RemoveSandboxRootOptions {
+    tempDir?: string;
+    now?: () => number;
+    isProcessAlive?: (pid: number) => boolean;
+}
+
+function isProcessAlive(pid: number): boolean {
+    try {
+        process.kill(pid, 0);
+        return true;
+    } catch (error) {
+        // A process we cannot signal is still live. Unknown failures are also
+        // preserved: cleanup must fail safe rather than delete a live trial.
+        return (error as NodeJS.ErrnoException).code !== 'ESRCH';
+    }
+}
+
+async function readOwnedSandboxMarker(rootDir: string): Promise<SandboxMarker | undefined> {
+    const rootStat = await fs.lstat(rootDir);
+    if (!rootStat.isDirectory() || rootStat.isSymbolicLink()) return undefined;
+
+    const markerPath = path.join(rootDir, SANDBOX_MARKER);
+    const markerStat = await fs.lstat(markerPath);
+    if (!markerStat.isFile() || markerStat.isSymbolicLink()) return undefined;
+
+    const marker = JSON.parse(await fs.readFile(markerPath, 'utf8')) as Partial<SandboxMarker>;
+    const pid = marker.pid;
+    if (marker.version !== 1 || typeof pid !== 'number' || !Number.isSafeInteger(pid) || pid <= 0) return undefined;
+
+    return { version: 1, pid };
+}
+
+async function isStaleOwnedSandbox(
+    rootDir: string,
+    now: number,
+    staleAfterMs: number,
+    processIsAlive: (pid: number) => boolean,
+): Promise<boolean> {
+    const marker = await readOwnedSandboxMarker(rootDir);
+    if (!marker) return false;
+
+    const markerStat = await fs.lstat(path.join(rootDir, SANDBOX_MARKER));
+    if (now - markerStat.mtimeMs < staleAfterMs) return false;
+
+    return !processIsAlive(marker.pid);
+}
+
+/**
+ * Removes old, crashed PathGrade sandboxes without examining anything outside
+ * the resolved operating-system temp directory. Every filesystem failure is
+ * intentionally ignored so a cleanup race never prevents a new trial.
+ */
+export async function cleanupStaleSandboxes(opts: StaleSandboxCleanupOptions = {}): Promise<void> {
+    let tempDir: string;
+    try {
+        tempDir = await fs.realpath(opts.tempDir ?? os.tmpdir());
+    } catch {
+        return;
+    }
+
+    const now = opts.now ?? Date.now;
+    const processIsAlive = opts.isProcessAlive ?? isProcessAlive;
+    let entries: fs.Dirent[];
+    try {
+        entries = await fs.readdir(tempDir, { withFileTypes: true });
+    } catch {
+        return;
+    }
+
+    for (const entry of entries) {
+        if (!entry.isDirectory() || entry.isSymbolicLink() || !entry.name.startsWith(SANDBOX_PREFIX)) continue;
+
+        const rootDir = path.resolve(tempDir, entry.name);
+        if (path.dirname(rootDir) !== tempDir) continue;
+
+        try {
+            if (!await isStaleOwnedSandbox(rootDir, now(), STALE_SANDBOX_AGE_MS, processIsAlive)) continue;
+
+            // Re-check ownership and liveness immediately before removal. This
+            // narrows the window where another process can replace a candidate.
+            if (!await isStaleOwnedSandbox(rootDir, now(), STALE_SANDBOX_AGE_MS, processIsAlive)) continue;
+            await removeSandboxRoot(rootDir, opts);
+        } catch {
+            // A disappeared directory, a permission change, or a deletion race
+            // must never make trial creation fail.
+        }
+    }
+}
+
+export async function createSandboxRoot(): Promise<string> {
+    // A process may create many trial sandboxes. Scan only once at startup so
+    // repeated trials do not pay to enumerate the entire operating-system temp
+    // directory, while concurrent creators share the same best-effort sweep.
+    startupCleanup ??= cleanupStaleSandboxes();
+    await startupCleanup;
+    const tempDir = await fs.realpath(os.tmpdir());
+    const rootDir = await fs.mkdtemp(path.join(tempDir, SANDBOX_PREFIX));
+    const marker: SandboxMarker = { version: 1, pid: process.pid };
+    try {
+        await fs.writeFile(path.join(rootDir, SANDBOX_MARKER), JSON.stringify(marker), 'utf8');
+        return rootDir;
+    } catch (error) {
+        await fs.remove(rootDir).catch(() => {});
+        throw error;
+    }
+}

--- a/src/providers/sandbox.ts
+++ b/src/providers/sandbox.ts
@@ -2,6 +2,7 @@ import fs from 'fs-extra';
 import * as path from 'path';
 import * as os from 'os';
 import { DEFAULT_COPY_IGNORE, createCopyFilter, isPortableCopyEntry } from './copy-filter.js';
+import { createSandboxRoot } from './sandbox-lifecycle.js';
 
 
 export interface SandboxConfig {
@@ -31,7 +32,7 @@ export const SAFE_HOST_VARS = [
 ];
 
 export async function createSandbox(spec: SandboxConfig): Promise<Sandbox> {
-    const rootDir = path.join(os.tmpdir(), `pathgrade-${Math.random().toString(36).substring(7)}`);
+    const rootDir = await createSandboxRoot();
     const workspacePath = path.join(rootDir, 'workspace');
     const homePath = path.join(rootDir, 'home');
     const tmpPath = path.join(rootDir, 'tmp');

--- a/src/providers/workspace.ts
+++ b/src/providers/workspace.ts
@@ -2,6 +2,7 @@ import fs from 'fs-extra';
 import * as os from 'os';
 import * as path from 'path';
 import { createSandbox, type SandboxConfig } from './sandbox.js';
+import { removeSandboxRoot } from './sandbox-lifecycle.js';
 import { stageMcpConfig } from './mcp-config.js';
 import { sandboxExec } from './sandbox-exec.js';
 import { resolveCredentials } from './credentials.js';
@@ -17,49 +18,6 @@ export interface Workspace {
     readonly setupCommands: string[];
     exec(command: string, opts?: { signal?: AbortSignal }): Promise<CommandResult>;
     dispose(): Promise<void>;
-}
-
-const SANDBOX_REMOVE_RETRY_DELAYS_MS = [
-    50,
-    100,
-    250,
-    500,
-    1_000,
-    2_000,
-    3_000,
-    5_000,
-];
-
-interface RemoveSandboxRootOptions {
-    remove?: (target: string) => Promise<void>;
-    sleep?: (ms: number) => Promise<void>;
-    retryDelaysMs?: readonly number[];
-}
-
-function isRetryableRemoveError(error: unknown): boolean {
-    const code = (error as NodeJS.ErrnoException).code;
-    return code === 'ENOTEMPTY' || code === 'EBUSY' || code === 'EPERM';
-}
-
-export async function removeSandboxRoot(
-    rootDir: string,
-    opts: RemoveSandboxRootOptions = {},
-): Promise<void> {
-    const remove = opts.remove ?? ((target) => fs.remove(target));
-    const sleep = opts.sleep ?? ((ms) => new Promise<void>((resolve) => setTimeout(resolve, ms)));
-    const retryDelaysMs = opts.retryDelaysMs ?? SANDBOX_REMOVE_RETRY_DELAYS_MS;
-
-    for (let attempt = 0; ; attempt++) {
-        try {
-            await remove(rootDir);
-            return;
-        } catch (error) {
-            if (!isRetryableRemoveError(error) || attempt >= retryDelaysMs.length) {
-                throw error;
-            }
-            await sleep(retryDelaysMs[attempt]);
-        }
-    }
 }
 
 async function copyPathsFromHostHome(pathsToCopy: string[], sandboxHomePath: string): Promise<void> {

--- a/tests/sandbox-cleanup.test.ts
+++ b/tests/sandbox-cleanup.test.ts
@@ -1,0 +1,92 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import * as fs from 'fs-extra';
+import * as os from 'os';
+import * as path from 'path';
+import { cleanupStaleSandboxes, SANDBOX_MARKER } from '../src/providers/sandbox-lifecycle.js';
+
+const OLD = new Date(Date.now() - 25 * 60 * 60 * 1_000);
+
+describe('cleanupStaleSandboxes', () => {
+    let tempDir: string | undefined;
+
+    afterEach(async () => {
+        if (tempDir) await fs.remove(tempDir);
+    });
+
+    async function makeSandbox(name: string, options: { old?: boolean; pid?: number } = {}): Promise<string> {
+        const root = path.join(tempDir!, name);
+        await fs.ensureDir(root);
+        const marker = path.join(root, SANDBOX_MARKER);
+        await fs.writeFile(marker, JSON.stringify({ version: 1, pid: options.pid ?? 12345 }));
+        if (options.old) await fs.utimes(marker, OLD, OLD);
+        return root;
+    }
+
+    async function cleanup(options: Parameters<typeof cleanupStaleSandboxes>[0] = {}): Promise<void> {
+        await cleanupStaleSandboxes({ tempDir, isProcessAlive: () => false, ...options });
+    }
+
+    it('deletes a stale owned sandbox', async () => {
+        tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'pathgrade-cleanup-test-'));
+        const stale = await makeSandbox('pathgrade-stale', { old: true });
+
+        await cleanup();
+
+        expect(await fs.pathExists(stale)).toBe(false);
+    });
+
+    it('preserves a recent sandbox and an old sandbox with a live owner', async () => {
+        tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'pathgrade-cleanup-test-'));
+        const recent = await makeSandbox('pathgrade-recent');
+        const live = await makeSandbox('pathgrade-live', { old: true, pid: 999 });
+
+        await cleanup({ isProcessAlive: (pid) => pid === 999 });
+
+        expect(await fs.pathExists(recent)).toBe(true);
+        expect(await fs.pathExists(live)).toBe(true);
+    });
+
+    it('preserves unrelated and unmarked PathGrade-looking directories', async () => {
+        tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'pathgrade-cleanup-test-'));
+        const unrelated = path.join(tempDir, 'other-tool');
+        const unmarked = path.join(tempDir, 'pathgrade-not-a-sandbox');
+        await fs.ensureDir(unrelated);
+        await fs.ensureDir(unmarked);
+        await fs.writeFile(path.join(unrelated, 'keep.txt'), 'keep');
+        await fs.writeFile(path.join(unmarked, 'keep.txt'), 'keep');
+
+        await cleanup();
+
+        expect(await fs.readFile(path.join(unrelated, 'keep.txt'), 'utf8')).toBe('keep');
+        expect(await fs.readFile(path.join(unmarked, 'keep.txt'), 'utf8')).toBe('keep');
+    });
+
+    it('tolerates deletion races and failures without rejecting', async () => {
+        tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'pathgrade-cleanup-test-'));
+        const stale = await makeSandbox('pathgrade-racy', { old: true });
+        const remove = vi.fn(async () => {
+            throw Object.assign(new Error('gone'), { code: 'ENOENT' });
+        });
+
+        await expect(cleanup({ remove })).resolves.toBeUndefined();
+        expect(remove).toHaveBeenCalledWith(await fs.realpath(stale));
+        expect(await fs.pathExists(stale)).toBe(true);
+    });
+
+    it('does not follow a PathGrade-named symlink outside the temp root', async () => {
+        tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'pathgrade-cleanup-test-'));
+        const outside = await fs.mkdtemp(path.join(os.tmpdir(), 'pathgrade-cleanup-outside-'));
+        const link = path.join(tempDir, 'pathgrade-escape');
+        try {
+            await fs.writeFile(path.join(outside, 'keep.txt'), 'keep');
+            await fs.symlink(outside, link);
+
+            await cleanup();
+
+            expect((await fs.lstat(link)).isSymbolicLink()).toBe(true);
+            expect(await fs.readFile(path.join(outside, 'keep.txt'), 'utf8')).toBe('keep');
+        } finally {
+            await fs.remove(outside);
+        }
+    });
+});

--- a/tests/workspace.test.ts
+++ b/tests/workspace.test.ts
@@ -2,7 +2,8 @@ import { describe, it, expect, afterEach, vi } from 'vitest';
 import * as fs from 'fs-extra';
 import * as path from 'path';
 import * as os from 'os';
-import { prepareWorkspace, linkPathsFromHostHome, removeSandboxRoot, Workspace } from '../src/providers/workspace.js';
+import { prepareWorkspace, linkPathsFromHostHome, Workspace } from '../src/providers/workspace.js';
+import { removeSandboxRoot } from '../src/providers/sandbox-lifecycle.js';
 
 describe('prepareWorkspace — MCP config', () => {
     let workspace: Workspace | undefined;


### PR DESCRIPTION
## Summary

PathGrade trial sandboxes can remain in the OS temp directory after a crash or interrupt. Over time these residues consume disk space and can expose stale trial state.

This is the smallest startup-time cleanup:
- New sandboxes carry a private ownership marker containing the creator PID.
- Once per process startup, PathGrade scans only immediate children of the resolved OS temp directory.
- A candidate must be a non-symlink `pathgrade-*` directory with a valid, non-symlink marker; unmarked or unrelated directories are never removed.
- It is removable only when its marker is at least 24 hours old and its PID is no longer alive (permission/unknown PID checks fail safe as live).
- Ownership and liveness are rechecked immediately before removal; listing, stat, parse, and deletion races/failures are swallowed so trial creation continues.

The existing retry-aware sandbox root removal logic was moved into the cleanup module and reused.

## Verification

- `yarn build`
- Focused Vitest coverage: stale deletion, recent/live preservation, unrelated/unmarked preservation, failure tolerance, and symlink target boundary (68 focused tests passed)
- `yarn test` (1,249 passed, 16 skipped)
- `yarn quality` (passed)

## Residual risks

- Sandboxes from versions before the ownership marker are intentionally preserved: name-only deletion is not safe enough.
- A stale PID reused by the OS can conservatively retain a stale sandbox.
- Cleanup runs once per process to bound startup overhead; residues created after that sweep wait for a later process startup.