### PR TITLE
fix: avoid copying Claude config for OAuth

### DIFF
--- a/src/providers/credentials.ts
+++ b/src/providers/credentials.ts
@@ -152,7 +152,7 @@ async function resolveClaude(
             return {
                 env: { PATHGRADE_CLAUDE_LOCAL_OAUTH: '1' },
                 setupCommands: [],
-                copyFromHome: ['.claude.json'],
+                copyFromHome: [],
                 linkFromHome: ['Library/Keychains'],
             };
         }

--- a/tests/credentials.test.ts
+++ b/tests/credentials.test.ts
@@ -59,7 +59,7 @@ describe('resolveCredentials', () => {
             }),
         );
         expect(result.env).toEqual({ PATHGRADE_CLAUDE_LOCAL_OAUTH: '1' });
-        expect(result.copyFromHome).toEqual(['.claude.json']);
+        expect(result.copyFromHome).toEqual([]);
         expect(result.linkFromHome).toEqual(['Library/Keychains']);
     });
 
@@ -75,6 +75,8 @@ describe('resolveCredentials', () => {
             ANTHROPIC_API_KEY: 'sk-host',
             ANTHROPIC_BASE_URL: 'https://api.anthropic.com',
         });
+        expect(result.copyFromHome).toEqual([]);
+        expect(result.linkFromHome).toBeUndefined();
     });
 
     it('claude: no user env + nothing → empty', async () => {
@@ -114,7 +116,7 @@ describe('resolveCredentials', () => {
             }),
         );
         expect(result.env).toEqual({ PATHGRADE_CLAUDE_LOCAL_OAUTH: '1' });
-        expect(result.copyFromHome).toEqual(['.claude.json']);
+        expect(result.copyFromHome).toEqual([]);
         expect(result.linkFromHome).toEqual(['Library/Keychains']);
     });
 


### PR DESCRIPTION
## Problem

macOS Claude OAuth trials copied the host ~/.claude.json into the isolated trial HOME, unnecessarily exposing host configuration.

## Smallest fix

Keep the existing local-OAuth marker and Library/Keychains symlink, but request no .claude.json host copy for the Claude OAuth credential path.

## Verification

- yarn vitest run tests/credentials.test.ts (25 passed)
- yarn build
- yarn lint
- yarn test (1,244 passed, 16 skipped)
- yarn quality (passed; only documented legacy line-count exemptions)

## Residual risk

The forced expired-token refresh path remains untested in this change. The successful OAuth selection is unit-tested through credential resolution, while live Keychain refresh behavior is unchanged and still depends on the Claude SDK/Keychain integration.