### PR TITLE
fix: isolate Claude OAuth trials from Claude.ai MCP connectors

### DIFF
--- a/src/agents/claude/sdk-options.ts
+++ b/src/agents/claude/sdk-options.ts
@@ -121,6 +121,12 @@ export function buildClaudeSdkOptions(inputs: ClaudeSdkOptionsInputs): Options {
         if (key === 'PATHGRADE_CLAUDE_LOCAL_OAUTH') continue;
         env[key] = value;
     }
+    // Claude Code normally exposes claude.ai account-level MCP connectors to
+    // local OAuth sessions. Keep PathGrade trials isolated from those ambient
+    // connectors unless the caller explicitly opts in through their env.
+    if (useLocalOAuth && env.ENABLE_CLAUDEAI_MCP_SERVERS === undefined) {
+        env.ENABLE_CLAUDEAI_MCP_SERVERS = 'false';
+    }
     if (!useLocalOAuth) {
         env.CLAUDE_CONFIG_DIR = path.join(inputs.workspacePath, CLAUDE_CONFIG_SUBDIR);
     }

--- a/tests/claude-sdk-options.test.ts
+++ b/tests/claude-sdk-options.test.ts
@@ -124,14 +124,51 @@ describe('buildClaudeSdkOptions — env (TB5)', () => {
         expect(opts.env!.CLAUDE_CONFIG_DIR).toBe('/tmp/trial-42/.pathgrade-claude-config');
     });
 
-    it('uses host Claude Code config when local OAuth is selected', () => {
+    it('defaults claude.ai account-level MCP servers off for local OAuth', () => {
         const opts = buildClaudeSdkOptions(baseInputs({
             workspacePath: '/tmp/trial-oauth',
             runtimeEnv: { PATHGRADE_CLAUDE_LOCAL_OAUTH: '1' },
         }));
         expect(opts.env).toBeDefined();
         expect('CLAUDE_CONFIG_DIR' in opts.env!).toBe(false);
+        expect(opts.env!.ENABLE_CLAUDEAI_MCP_SERVERS).toBe('false');
+    });
+
+    it('preserves explicit claude.ai MCP connector opt-in for local OAuth', () => {
+        const opts = buildClaudeSdkOptions(baseInputs({
+            runtimeEnv: {
+                PATHGRADE_CLAUDE_LOCAL_OAUTH: '1',
+                ENABLE_CLAUDEAI_MCP_SERVERS: 'true',
+            },
+        }));
+        expect(opts.env!.ENABLE_CLAUDEAI_MCP_SERVERS).toBe('true');
+    });
+
+    it('preserves an explicit claude.ai MCP connector setting over the OAuth default', () => {
+        const opts = buildClaudeSdkOptions(baseInputs({
+            runtimeEnv: {
+                PATHGRADE_CLAUDE_LOCAL_OAUTH: '1',
+                ENABLE_CLAUDEAI_MCP_SERVERS: 'false',
+            },
+        }));
+        expect(opts.env!.ENABLE_CLAUDEAI_MCP_SERVERS).toBe('false');
+    });
+
+    it('does not leak the internal local OAuth marker into the SDK environment', () => {
+        const opts = buildClaudeSdkOptions(baseInputs({
+            runtimeEnv: { PATHGRADE_CLAUDE_LOCAL_OAUTH: '1' },
+        }));
         expect('PATHGRADE_CLAUDE_LOCAL_OAUTH' in opts.env!).toBe(false);
+    });
+
+    it('does not add the claude.ai MCP setting to API-key or proxy paths', () => {
+        const opts = buildClaudeSdkOptions(baseInputs({
+            runtimeEnv: {
+                ANTHROPIC_API_KEY: 'sk-test',
+                ANTHROPIC_BASE_URL: 'https://proxy.example/v1',
+            },
+        }));
+        expect('ENABLE_CLAUDEAI_MCP_SERVERS' in opts.env!).toBe(false);
     });
 
     it('does not set Options.env keys whose values are undefined in the auth env', () => {


### PR DESCRIPTION
## Problem

Local macOS Claude OAuth trials could inherit Claude.ai account-level MCP connectors, making trial behavior depend on ambient account configuration.

## Smallest fix

At the Claude SDK options boundary, PathGrade now sets `ENABLE_CLAUDEAI_MCP_SERVERS=false` only when the internal local-OAuth marker is active.

## Explicit opt-in and precedence

An explicitly supplied `ENABLE_CLAUDEAI_MCP_SERVERS` value is preserved, including `true` for opt-in. API-key and proxy execution paths remain untouched and receive no default setting. The internal OAuth marker is still stripped before the SDK subprocess is launched.

## Verification

- `yarn vitest run tests/claude-sdk-options.test.ts` (27 passed)
- `yarn build`
- `yarn vitest run tests/claude-sdk-options.test.ts tests/claude-sdk-driver.test.ts tests/credentials.test.ts` (67 passed)
- `yarn lint`
- `yarn quality`
- `yarn test` (149 files passed, 4 skipped; 1,248 tests passed, 16 skipped)

## Residual risks

This relies on Claude Code honoring the documented environment variable. The change intentionally does not alter `.claude.json` copying or stale-sandbox cleanup, which remain outside this branch.