### PR TITLE
Fix Codex judges to use local CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,8 @@ Judge scorers also support:
 - `input` for extra context such as generated file contents or command output
 - `tools` to let the judge LLM read workspace artifacts itself via a bounded tool-use loop (`readFile`, `listDir`, `grep`, `getToolEvents`)
 
+Plain Codex judges reuse the authenticated local Codex CLI first. `OPENAI_API_KEY` remains an optional HTTP fallback.
+
 Example with artifact-backed input:
 
 ```typescript

--- a/src/utils/llm-providers/cli.ts
+++ b/src/utils/llm-providers/cli.ts
@@ -5,19 +5,29 @@ import type { LLMProvider, LLMCallOptions, LLMCallResult } from '../llm-types.js
 
 const availabilityPromises = new Map<string, Promise<boolean>>();
 
-function getCliAvailability(command: string, args: string[], timeoutSec: number): Promise<boolean> {
-    const cacheKey = `${command} ${args.join(' ')}`;
+function getCliAvailability(
+    command: string,
+    args: string[],
+    timeoutSec: number,
+    env: Record<string, string | undefined> = {},
+): Promise<boolean> {
+    const cacheKey = JSON.stringify([command, args, env.PATH, env.CODEX_HOME]);
     const existing = availabilityPromises.get(cacheKey);
     if (existing) return existing;
 
-    const promise = checkCliAvailability(command, args, timeoutSec);
+    const promise = checkCliAvailability(command, args, timeoutSec, env);
     availabilityPromises.set(cacheKey, promise);
     return promise;
 }
 
-async function checkCliAvailability(command: string, args: string[], timeoutSec: number): Promise<boolean> {
+async function checkCliAvailability(
+    command: string,
+    args: string[],
+    timeoutSec: number,
+    env: Record<string, string | undefined>,
+): Promise<boolean> {
     try {
-        const result = await runCli(command, args, {}, timeoutSec);
+        const result = await runCli(command, args, env, timeoutSec);
         return result.exitCode === 0;
     } catch {
         return false;
@@ -34,8 +44,8 @@ export async function isClaudeCliAvailable(): Promise<boolean> {
     return getCliAvailability('claude', ['auth', 'status'], 5);
 }
 
-export async function isCodexCliAvailable(): Promise<boolean> {
-    return getCliAvailability('codex', ['login', 'status'], 5);
+export async function isCodexCliAvailable(env: Record<string, string | undefined> = {}): Promise<boolean> {
+    return getCliAvailability('codex', ['login', 'status'], 5, env);
 }
 
 // --- JSON envelope parsing ---
@@ -80,6 +90,7 @@ export function extractStructuredOutput(raw: string): string {
 
 export const cliProvider: LLMProvider = {
     name: 'cli',
+    modelFamily: 'anthropic',
 
     async isAvailable(): Promise<boolean> {
         return isClaudeCliAvailable();
@@ -155,6 +166,53 @@ export const cliProvider: LLMProvider = {
             outputTokens: usage?.output_tokens,
             provider: 'cli',
             model: opts.model || 'claude-cli',
+        };
+    },
+};
+
+export const codexCliProvider: LLMProvider = {
+    name: 'codex-cli',
+    modelFamily: 'openai',
+
+    async isAvailable(env): Promise<boolean> {
+        return isCodexCliAvailable(env);
+    },
+
+    supportsModel(model: string): boolean {
+        const normalized = model.trim().toLowerCase();
+        return normalized.startsWith('gpt-')
+            || normalized.startsWith('chatgpt-')
+            || normalized.startsWith('o1')
+            || normalized.startsWith('o3')
+            || normalized.startsWith('o4');
+    },
+
+    async call(prompt: string, opts: LLMCallOptions): Promise<LLMCallResult> {
+        const args = [
+            'exec',
+            '--ephemeral',
+            '--skip-git-repo-check',
+            '--sandbox',
+            'read-only',
+            '--color',
+            'never',
+        ];
+        if (opts.model) {
+            args.push('--model', opts.model);
+        }
+        args.push('-');
+
+        const result = await runCli('codex', args, opts.env ?? {}, 120, prompt);
+        if (result.exitCode !== 0) {
+            throw new Error(
+                `Codex CLI exited with code ${result.exitCode}: ${result.stderr.slice(0, 300)}`
+            );
+        }
+
+        return {
+            text: result.stdout.trim(),
+            provider: 'cli',
+            model: opts.model || 'codex-cli',
         };
     },
 };

--- a/src/utils/llm-types.ts
+++ b/src/utils/llm-types.ts
@@ -109,6 +109,8 @@ export type CallWithToolsResult =
 /** Wide implementor-facing type — each provider adapter implements this. */
 export interface LLMProviderAdapter {
     name: string;
+    /** Model family served by adapters whose transport name differs from the API provider name. */
+    modelFamily?: 'anthropic' | 'openai';
     isAvailable(env?: Record<string, string>): Promise<boolean>;
     call(prompt: string, opts: LLMCallOptions): Promise<LLMCallResult>;
     callWithTools?(messages: ToolUseMessage[], opts: CallWithToolsOptions): Promise<CallWithToolsResult>;

--- a/src/utils/llm.ts
+++ b/src/utils/llm.ts
@@ -8,7 +8,7 @@ import type {
     ToolUseMessage,
     TokenUsage,
 } from './llm-types.js';
-import { cliProvider } from './llm-providers/cli.js';
+import { cliProvider, codexCliProvider } from './llm-providers/cli.js';
 import { anthropicProvider } from './llm-providers/anthropic.js';
 import { openaiProvider } from './llm-providers/openai.js';
 
@@ -142,7 +142,7 @@ export function createLLMClient(
             // If model explicitly targets a provider type (e.g., "gpt-4o" → openai),
             // narrow to only providers of that type
             const narrowed = requestedProviderType
-                ? candidates.filter((p) => p.name === requestedProviderType)
+                ? candidates.filter((p) => (p.modelFamily ?? p.name) === requestedProviderType)
                 : candidates;
 
             // Try narrowed set first, then fall back to all candidates
@@ -195,7 +195,7 @@ export function createLLMClient(
             }
             if (agentName === 'codex') {
                 throw new Error(
-                    'Codex CLI not found on PATH. Install with: npm install -g @openai/codex'
+                    'Codex judge requires an authenticated Codex CLI or OPENAI_API_KEY.'
                 );
             }
             if (agentName === 'cursor') {
@@ -237,7 +237,7 @@ export async function callLLM(prompt: string, opts: LLMCallOptions = {}): Promis
  * Create an LLM client scoped to the providers that match the given agent.
  *
  * - claude → CLI + Anthropic API (no OpenAI fallthrough)
- * - codex  → OpenAI API
+ * - codex  → Codex CLI + OpenAI API
  *
  * If `agentEnv` is provided, it is merged into every LLM call so that
  * the agent's env propagates to persona/judge/summarization calls.
@@ -250,11 +250,12 @@ export function createAgentLLM(agentName: string, agentEnv?: Record<string, stri
     // harnesses — see PRD §"LLM-backend routing"). Cursor evals therefore
     // depend on Claude CLI or ANTHROPIC_API_KEY being available at judge time.
     const baseAdapters = agentName === 'codex'
-        ? [openaiProvider]
+        ? [codexCliProvider, openaiProvider]
         : [cliProvider, anthropicProvider];
     const adapters = agentEnv && Object.keys(agentEnv).length > 0
         ? baseAdapters.map<LLMProviderAdapter>((a) => ({
             ...a,
+            isAvailable: (env) => a.isAvailable({ ...agentEnv, ...env }),
             call: (prompt, opts) => a.call(prompt, { ...opts, env: { ...agentEnv, ...opts.env } }),
             ...(a.callWithTools
                 ? { callWithTools: (messages, opts) => a.callWithTools!(messages, { ...opts, env: { ...agentEnv, ...opts.env } }) }

--- a/tests/codex-cli-llm.test.ts
+++ b/tests/codex-cli-llm.test.ts
@@ -1,0 +1,112 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+import { createAgentLLM } from '../src/utils/llm.js';
+import { resetCliCache } from '../src/utils/llm-providers/cli.js';
+
+const temporaryDirectories: string[] = [];
+
+afterEach(async () => {
+    resetCliCache();
+    await Promise.all(temporaryDirectories.splice(0).map((directory) =>
+        rm(directory, { recursive: true, force: true })
+    ));
+});
+
+describe('Codex CLI judge provider', () => {
+    it('uses an authenticated local Codex CLI without OPENAI_API_KEY', async () => {
+        const binDirectory = await mkdtemp(path.join(tmpdir(), 'pathgrade-codex-bin-'));
+        temporaryDirectories.push(binDirectory);
+        const executable = path.join(binDirectory, 'codex');
+        await writeFile(executable, `#!/bin/sh
+if [ "$1" = "login" ] && [ "$2" = "status" ]; then
+  exit 0
+fi
+if [ "$1" = "exec" ]; then
+  prompt=$(cat)
+  printf '{"score":1,"details":"local judge saw: %s"}' "$prompt"
+  exit 0
+fi
+exit 1
+`, { mode: 0o755 });
+
+        const originalPath = process.env.PATH;
+        process.env.PATH = '/usr/bin:/bin';
+        try {
+            const llm = createAgentLLM('codex', {
+                PATH: `${binDirectory}:${originalPath ?? ''}`,
+                OPENAI_API_KEY: '',
+            });
+
+            const result = await llm.call('grade this transcript');
+
+            expect(result.provider).toBe('cli');
+            expect(result.text).toContain('local judge saw: grade this transcript');
+        } finally {
+            process.env.PATH = originalPath;
+        }
+    });
+
+    it('keeps the local CLI ahead of the API fallback for an explicit GPT model', async () => {
+        const binDirectory = await mkdtemp(path.join(tmpdir(), 'pathgrade-codex-bin-'));
+        temporaryDirectories.push(binDirectory);
+        const executable = path.join(binDirectory, 'codex');
+        await writeFile(executable, `#!/bin/sh
+if [ "$1" = "login" ] && [ "$2" = "status" ]; then
+  exit 0
+fi
+if [ "$1" = "exec" ]; then
+  cat >/dev/null
+  printf '{"score":1,"details":"local judge"}'
+  exit 0
+fi
+exit 1
+`, { mode: 0o755 });
+        const fetchSpy = vi.spyOn(globalThis, 'fetch').mockRejectedValue(
+            new Error('HTTP judge should not run before the local CLI')
+        );
+
+        try {
+            const llm = createAgentLLM('codex', {
+                PATH: `${binDirectory}:${process.env.PATH ?? ''}`,
+                OPENAI_API_KEY: 'configured-fallback-key',
+            });
+
+            const result = await llm.call('grade this transcript', { model: 'gpt-5.4' });
+
+            expect(result.provider).toBe('cli');
+            expect(fetchSpy).not.toHaveBeenCalled();
+        } finally {
+            fetchSpy.mockRestore();
+        }
+    });
+
+    it('reports the actual judge-provider requirements when neither route is available', async () => {
+        const emptyBinDirectory = await mkdtemp(path.join(tmpdir(), 'pathgrade-empty-bin-'));
+        temporaryDirectories.push(emptyBinDirectory);
+        const originalPath = process.env.PATH;
+        const originalApiKey = process.env.OPENAI_API_KEY;
+        process.env.PATH = '/usr/bin:/bin';
+        delete process.env.OPENAI_API_KEY;
+
+        try {
+            const llm = createAgentLLM('codex', {
+                PATH: emptyBinDirectory,
+                OPENAI_API_KEY: '',
+            });
+
+            await expect(llm.call('grade this transcript')).rejects.toThrow(
+                'Codex judge requires an authenticated Codex CLI or OPENAI_API_KEY'
+            );
+        } finally {
+            process.env.PATH = originalPath;
+            if (originalApiKey === undefined) {
+                delete process.env.OPENAI_API_KEY;
+            } else {
+                process.env.OPENAI_API_KEY = originalApiKey;
+            }
+        }
+    });
+});


### PR DESCRIPTION
## What changed

- add a Codex CLI-backed provider for plain judge calls
- prefer the authenticated local CLI before the OpenAI HTTP fallback
- preserve local-first ordering when an explicit GPT model is selected
- propagate the agent environment into provider availability checks
- replace the misleading install message with the actual judge-provider requirements
- document the local-first Codex judge behavior

## Why

In `@wix/pathgrade@1.0.1`, Codex agent turns can run through the installed local CLI, but rubric judges are routed only through the OpenAI HTTP provider. Without `OPENAI_API_KEY`, PathGrade skips the judge and incorrectly reports that the Codex CLI is missing even when it is installed and authenticated.

## Impact

Plain Codex judges now work with `codex login` authentication and no API key. Existing API-backed judging remains available as a fallback. Tool-using judge behavior is unchanged.

## Verification

- `TMPDIR=/tmp corepack yarn test`
  - 151 test files passed; 4 skipped
  - 1,256 tests passed; 16 skipped
  - runner CLI smoke passed
- `corepack yarn quality:boundaries`
- `corepack yarn quality:max-lines`
- real local smoke with `OPENAI_API_KEY` unset returned:

```json
{"provider":"cli","model":"codex-cli","text":"{\"score\":1,\"details\":\"local-smoke\"}"}
```
